### PR TITLE
feat: order now will be returned as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,8 @@ A `snapshot` represents the state of the order book at a specific point in time.
 Snapshots are crucial for restoring the order book to a previous state. The orderbook can restore from a snapshot before processing any journal logs, ensuring consistency and accuracy.
 After taking the snapshot, you can safely remove all logs preceding the `lastOp` id.
 
+**Note**: The snapshot of the order book returns an object containing an `array` of `bids` and `asks`, which in turn are arrays of order objects. If the snapshot is saved to the database as a `string`, make sure to pass the snapshot in its original format when initializing the order book. For example, you can achieve this by using `JSON.parse` to convert the string back into its original object form.
+
 ```js
 const ob = new OrderBook({ enableJournaling: true})
 

--- a/src/order.ts
+++ b/src/order.ts
@@ -13,6 +13,7 @@ import {
 	type Side,
 	type TimeInForce,
 } from "./types";
+import { safeStringify } from "./utils";
 
 abstract class BaseOrder {
 	readonly _id: string;
@@ -141,7 +142,7 @@ export class LimitOrder extends BaseOrder {
     makerQty: ${this._makerQty}
     takerQty: ${this._takerQty}`;
 
-	toJSON = (): string => JSON.stringify(this.toObject());
+	toJSON = (): string | null => safeStringify(this.toObject());
 
 	toObject = (): ILimitOrder => ({
 		id: this._id,
@@ -184,7 +185,7 @@ export class StopMarketOrder extends BaseOrder {
     stopPrice: ${this._stopPrice}
     time: ${this._time}`;
 
-	toJSON = (): string => JSON.stringify(this.toObject());
+	toJSON = (): string | null => safeStringify(this.toObject());
 
 	toObject = (): IStopMarketOrder => ({
 		id: this._id,
@@ -249,10 +250,11 @@ export class StopLimitOrder extends BaseOrder {
     size: ${this._size}
     price: ${this._price}
     stopPrice: ${this._stopPrice}
+	isOCO: ${this.isOCO}
     timeInForce: ${this._timeInForce}
     time: ${this._time}`;
 
-	toJSON = (): string => JSON.stringify(this.toObject());
+	toJSON = (): string | null => safeStringify(this.toObject());
 
 	toObject = (): IStopLimitOrder => ({
 		id: this._id,
@@ -261,6 +263,7 @@ export class StopLimitOrder extends BaseOrder {
 		size: this._size,
 		price: this._price,
 		stopPrice: this._stopPrice,
+		isOCO: this.isOCO,
 		timeInForce: this._timeInForce,
 		time: this._time,
 	});

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,7 @@ export interface IStopLimitOrder {
 	stopPrice: number;
 	timeInForce: TimeInForce;
 	time: number;
+	isOCO: boolean;
 }
 
 /**
@@ -168,16 +169,19 @@ export type StopOrderOptions =
 	| StopLimitOrderOptions
 	| OCOOrderOptions;
 
+export type IStopOrder = IStopLimitOrder | IStopMarketOrder;
+export type IOrder = ILimitOrder | IStopOrder;
+
 /**
  * Represents the result of processing an order.
  */
 export interface IProcessOrder {
 	/** Array of fully processed orders. */
-	done: Order[];
+	done: IOrder[];
 	/** Array of activated (stop limit or stop market) orders */
-	activated: StopOrder[];
+	activated: IStopOrder[];
 	/** The partially processed order, if any. */
-	partial: LimitOrder | null;
+	partial: ILimitOrder | null;
 	/** The quantity that has been processed in the partial order. */
 	partialQuantityProcessed: number;
 	/** The remaining quantity that needs to be processed. */
@@ -331,8 +335,8 @@ export type CreateOrderOptions =
  * Represents a cancel order operation.
  */
 export interface ICancelOrder {
-	order: LimitOrder;
-	stopOrder?: StopOrder;
+	order: ILimitOrder;
+	stopOrder?: IStopOrder;
 	/** Optional log related to the order cancellation. */
 	log?: CancelOrderJournalLog;
 }
@@ -386,14 +390,14 @@ export interface Snapshot {
 		/** Price of the ask order */
 		price: number;
 		/** List of orders associated with this price */
-		orders: LimitOrder[];
+		orders: ILimitOrder[];
 	}>;
 	/** List of bid orders, each with a price and a list of associated orders */
 	bids: Array<{
 		/** Price of the bid order */
 		price: number;
 		/** List of orders associated with this price */
-		orders: LimitOrder[];
+		orders: ILimitOrder[];
 	}>;
 	/** Unix timestamp representing when the snapshot was taken */
 	ts: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,18 @@
+/* node:coverage ignore next - Don't know why this line is uncovered */
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export const safeStringify = (value: any): string | null => {
+	try {
+		return JSON.stringify(value);
+	} catch (error) {
+		return null;
+	}
+};
+
+/* node:coverage ignore next - Don't know why this line is uncovered */
+export const safeParse = <T>(value: string): T | null => {
+	try {
+		return JSON.parse(value);
+	} catch (error) {
+		return null;
+	}
+};

--- a/test/order.test.ts
+++ b/test/order.test.ts
@@ -45,7 +45,7 @@ void test("it should create LimitOrder", () => {
 		assert.equal(order.makerQty, size);
 		assert.equal(order.takerQty, 0);
 		assert.equal(order.ocoStopPrice, undefined);
-		assert.deepEqual(order.toObject(), {
+		assert.deepStrictEqual(order.toObject(), {
 			id,
 			type,
 			side,
@@ -115,7 +115,7 @@ void test("it should create LimitOrder", () => {
 		assert.equal(order.makerQty, size);
 		assert.equal(order.takerQty, 0);
 		assert.equal(order.ocoStopPrice, ocoStopPrice);
-		assert.deepEqual(order.toObject(), {
+		assert.deepStrictEqual(order.toObject(), {
 			id,
 			type,
 			side,
@@ -181,7 +181,7 @@ void test("it should create StopMarketOrder", () => {
 	assert.equal(order.size, size);
 	assert.equal(order.stopPrice, stopPrice);
 	assert.equal(order.time, time);
-	assert.deepEqual(order.toObject(), {
+	assert.deepStrictEqual(order.toObject(), {
 		id,
 		type,
 		side,
@@ -242,13 +242,14 @@ void test("it should create StopLimitOrder", () => {
 		assert.equal(order.timeInForce, timeInForce);
 		assert.equal(order.time, time);
 		assert.equal(order.isOCO, false);
-		assert.deepEqual(order.toObject(), {
+		assert.deepStrictEqual(order.toObject(), {
 			id,
 			type,
 			side,
 			size,
 			price,
 			stopPrice,
+			isOCO: false,
 			timeInForce,
 			time,
 		});
@@ -260,6 +261,7 @@ void test("it should create StopLimitOrder", () => {
     size: ${size}
     price: ${price}
     stopPrice: ${stopPrice}
+	isOCO: false
     timeInForce: ${timeInForce}
     time: ${time}`,
 		);
@@ -272,6 +274,7 @@ void test("it should create StopLimitOrder", () => {
 				size,
 				price,
 				stopPrice,
+				isOCO: false,
 				timeInForce,
 				time,
 			}),
@@ -306,13 +309,14 @@ void test("it should create StopLimitOrder", () => {
 		assert.equal(order.timeInForce, timeInForce);
 		assert.equal(order.time, time);
 		assert.equal(order.isOCO, true);
-		assert.deepEqual(order.toObject(), {
+		assert.deepStrictEqual(order.toObject(), {
 			id,
 			type,
 			side,
 			size,
 			price,
 			stopPrice,
+			isOCO: true,
 			timeInForce,
 			time,
 		});
@@ -324,6 +328,7 @@ void test("it should create StopLimitOrder", () => {
     size: ${size}
     price: ${price}
     stopPrice: ${stopPrice}
+	isOCO: true
     timeInForce: ${timeInForce}
     time: ${time}`,
 		);
@@ -336,6 +341,7 @@ void test("it should create StopLimitOrder", () => {
 				size,
 				price,
 				stopPrice,
+				isOCO: true,
 				timeInForce,
 				time,
 			}),
@@ -376,7 +382,7 @@ void test("it should create order without passing a date or id", (t) => {
 	});
 	assert.equal(order.id, fakeId);
 	assert.equal(order.time, fakeTimestamp);
-	assert.deepEqual(order.toObject(), {
+	assert.deepStrictEqual(order.toObject(), {
 		id: fakeId,
 		type,
 		side,

--- a/test/orderqueue.test.ts
+++ b/test/orderqueue.test.ts
@@ -35,14 +35,14 @@ void test("it should append/update/remove orders from queue", () => {
 
 	assert.equal(head instanceof LimitOrder, true);
 	assert.equal(tail instanceof LimitOrder, true);
-	assert.deepEqual(head, order1);
-	assert.deepEqual(tail, order2);
+	assert.deepStrictEqual(head, order1);
+	assert.deepStrictEqual(tail, order2);
 	assert.equal(oq.volume(), 10);
 	assert.equal(oq.len(), 2);
 	assert.equal(oq.price(), price);
 	const orders = oq.toArray();
-	assert.deepEqual(orders[0].toObject(), order1.toObject());
-	assert.deepEqual(orders[1].toObject(), order2.toObject());
+	assert.deepStrictEqual(orders[0].toObject(), order1.toObject());
+	assert.deepStrictEqual(orders[1].toObject(), order2.toObject());
 
 	const order3 = OrderFactory.createOrder({
 		type: OrderType.LIMIT,
@@ -64,8 +64,8 @@ void test("it should append/update/remove orders from queue", () => {
 
 	const head2 = oq.head();
 	const tail2 = oq.tail();
-	assert.deepEqual(head2, order3);
-	assert.deepEqual(tail2, order2);
+	assert.deepStrictEqual(head2, order3);
+	assert.deepStrictEqual(tail2, order2);
 
 	oq.remove(order3);
 
@@ -74,8 +74,8 @@ void test("it should append/update/remove orders from queue", () => {
 	const tail3 = oq.tail();
 	assert.equal(oq.len(), 1);
 	assert.equal(oq.volume(), 5);
-	assert.deepEqual(head3, order2);
-	assert.deepEqual(tail3, order2);
+	assert.deepStrictEqual(head3, order2);
+	assert.deepStrictEqual(tail3, order2);
 });
 
 void test("it should update order size and the volume", () => {

--- a/test/orderside.test.ts
+++ b/test/orderside.test.ts
@@ -48,8 +48,8 @@ void test("it should append/update/remove orders from queue on BUY side", () => 
 	);
 	assert.equal(os.len(), 2);
 	assert.equal(os.priceTree().length, 2);
-	assert.deepEqual(os.orders()[0], order1);
-	assert.deepEqual(os.orders()[1], order2);
+	assert.deepStrictEqual(os.orders()[0], order1);
+	assert.deepStrictEqual(os.orders()[1], order2);
 
 	assert.equal(os.lowerThan(21)?.price(), 20);
 	assert.equal(os.lowerThan(19)?.price(), 10);
@@ -72,7 +72,7 @@ void test("it should append/update/remove orders from queue on BUY side", () => 
 	assert.equal(os.len(), 2);
 	assert.equal(os.orders()[0].id, order1.id);
 	assert.equal(os.orders()[0].size, 10);
-	assert.deepEqual(os.orders()[1], order2);
+	assert.deepStrictEqual(os.orders()[1], order2);
 	assert.equal(os.toString(), "\n20 -> 5\n10 -> 10");
 
 	// Update order size without passing price, so the old order price will be used
@@ -83,7 +83,7 @@ void test("it should append/update/remove orders from queue on BUY side", () => 
 	assert.equal(os.len(), 2);
 	assert.equal(os.orders()[0].id, order1.id);
 	assert.equal(os.orders()[0].size, 5);
-	assert.deepEqual(os.orders()[1], order2);
+	assert.deepStrictEqual(os.orders()[1], order2);
 	assert.equal(os.toString(), "\n20 -> 5\n10 -> 5");
 
 	// When price is updated a new order will be created, so we can't match entire object, only properties
@@ -98,7 +98,7 @@ void test("it should append/update/remove orders from queue on BUY side", () => 
 	let updateOrder1 = os.orders()[0];
 	assert.equal(updateOrder1.size, 10);
 	assert.equal(updateOrder1.price, 15);
-	assert.deepEqual(os.orders()[1], order2);
+	assert.deepStrictEqual(os.orders()[1], order2);
 	assert.equal(os.toString(), "\n20 -> 5\n15 -> 10");
 
 	// Test for error when price level not exists
@@ -122,7 +122,7 @@ void test("it should append/update/remove orders from queue on BUY side", () => 
 	assert.equal(os.volume(), 15);
 	assert.equal(os.depth(), 1);
 	assert.equal(os.len(), 2);
-	assert.deepEqual(os.orders()[0], order2);
+	assert.deepStrictEqual(os.orders()[0], order2);
 	updateOrder1 = os.orders()[1];
 	assert.equal(updateOrder1.size, 10);
 	assert.equal(updateOrder1.price, 20);
@@ -136,7 +136,7 @@ void test("it should append/update/remove orders from queue on BUY side", () => 
 	assert.equal(os.volume(), 15);
 	assert.equal(os.depth(), 2);
 	assert.equal(os.len(), 2);
-	assert.deepEqual(os.orders()[0], order2);
+	assert.deepStrictEqual(os.orders()[0], order2);
 	updateOrder1 = os.orders()[1];
 	assert.equal(updateOrder1.size, 10);
 	assert.equal(updateOrder1.price, 25);
@@ -158,7 +158,7 @@ void test("it should append/update/remove orders from queue on BUY side", () => 
 	assert.equal(os.depth(), 1);
 	assert.equal(os.volume(), 5);
 	assert.equal(os.len(), 1);
-	assert.deepEqual(os.orders()[0], order2);
+	assert.deepStrictEqual(os.orders()[0], order2);
 
 	assert.equal(os.toString(), "\n20 -> 5");
 
@@ -215,8 +215,8 @@ void test("it should append/update/remove orders from queue on SELL side", () =>
 	);
 	assert.equal(os.len(), 2);
 	assert.equal(os.priceTree().length, 2);
-	assert.deepEqual(os.orders()[0], order1);
-	assert.deepEqual(os.orders()[1], order2);
+	assert.deepStrictEqual(os.orders()[0], order1);
+	assert.deepStrictEqual(os.orders()[1], order2);
 
 	assert.equal(os.lowerThan(21)?.price(), 20);
 	assert.equal(os.lowerThan(19)?.price(), 10);
@@ -239,7 +239,7 @@ void test("it should append/update/remove orders from queue on SELL side", () =>
 	assert.equal(os.len(), 2);
 	assert.equal(os.orders()[0].id, order1.id);
 	assert.equal(os.orders()[0].size, 10);
-	assert.deepEqual(os.orders()[1], order2);
+	assert.deepStrictEqual(os.orders()[1], order2);
 	assert.equal(os.toString(), "\n20 -> 5\n10 -> 10");
 
 	// When price is updated a new order will be created, so we can't match entire object, only properties
@@ -254,7 +254,7 @@ void test("it should append/update/remove orders from queue on SELL side", () =>
 	let updateOrder1 = os.orders()[0];
 	assert.equal(updateOrder1.size, 10);
 	assert.equal(updateOrder1.price, 15);
-	assert.deepEqual(os.orders()[1], order2);
+	assert.deepStrictEqual(os.orders()[1], order2);
 	assert.equal(os.toString(), "\n20 -> 5\n15 -> 10");
 
 	// Test for error when price level not exists
@@ -279,7 +279,7 @@ void test("it should append/update/remove orders from queue on SELL side", () =>
 	assert.equal(os.volume(), 15);
 	assert.equal(os.depth(), 1);
 	assert.equal(os.len(), 2);
-	assert.deepEqual(os.orders()[0], order2);
+	assert.deepStrictEqual(os.orders()[0], order2);
 	updateOrder1 = os.orders()[1];
 	assert.equal(updateOrder1.size, 10);
 	assert.equal(updateOrder1.price, 20);
@@ -293,7 +293,7 @@ void test("it should append/update/remove orders from queue on SELL side", () =>
 	assert.equal(os.volume(), 15);
 	assert.equal(os.depth(), 2);
 	assert.equal(os.len(), 2);
-	assert.deepEqual(os.orders()[0], order2);
+	assert.deepStrictEqual(os.orders()[0], order2);
 	updateOrder1 = os.orders()[1];
 	assert.equal(updateOrder1.size, 10);
 	assert.equal(updateOrder1.price, 25);
@@ -315,7 +315,7 @@ void test("it should append/update/remove orders from queue on SELL side", () =>
 	assert.equal(os.depth(), 1);
 	assert.equal(os.volume(), 5);
 	assert.equal(os.len(), 1);
-	assert.deepEqual(os.orders()[0], order2);
+	assert.deepStrictEqual(os.orders()[0], order2);
 
 	assert.equal(os.toString(), "\n20 -> 5");
 

--- a/test/stopbook.test.ts
+++ b/test/stopbook.test.ts
@@ -82,12 +82,12 @@ void test("it should add/remove/get order to stop book", () => {
 		assert.equal(totalOrder, 5);
 	}
 
-	assert.deepEqual(ob.remove(Side.SELL, "sell-3", 120)?.id, "sell-3");
+	assert.deepStrictEqual(ob.remove(Side.SELL, "sell-3", 120)?.id, "sell-3");
 	// @ts-expect-error asks is private
 	assert.equal(ob.asks._priceTree.length, 3);
 
 	// Lenght non changed because there were two orders at price level 100
-	assert.deepEqual(ob.remove(Side.BUY, "buy-2", 100)?.id, "buy-2");
+	assert.deepStrictEqual(ob.remove(Side.BUY, "buy-2", 100)?.id, "buy-2");
 	// @ts-expect-error asks is private
 	assert.equal(ob.bids._priceTree.length, 4);
 

--- a/test/stopqueue.test.ts
+++ b/test/stopqueue.test.ts
@@ -35,8 +35,8 @@ void test("it should append/remove orders from queue", () => {
 
 	assert.equal(head instanceof StopLimitOrder, true);
 	assert.equal(tail instanceof StopLimitOrder, true);
-	assert.deepEqual(head, order1);
-	assert.deepEqual(tail, order2);
+	assert.deepStrictEqual(head, order1);
+	assert.deepStrictEqual(tail, order2);
 	assert.equal(oq.len(), 2);
 
 	const order3 = OrderFactory.createOrder({
@@ -63,16 +63,16 @@ void test("it should append/remove orders from queue", () => {
 	oq.append(order4);
 	assert.equal(oq.len(), 4);
 
-	assert.deepEqual(oq.removeFromHead(), order1);
-	assert.deepEqual(oq.remove(order4.id), order4);
+	assert.deepStrictEqual(oq.removeFromHead(), order1);
+	assert.deepStrictEqual(oq.remove(order4.id), order4);
 	assert.equal(oq.len(), 2);
 
-	assert.deepEqual(oq.removeFromHead(), order2);
+	assert.deepStrictEqual(oq.removeFromHead(), order2);
 	assert.equal(oq.len(), 1);
 
 	assert.equal(oq.remove("fake-id"), undefined);
 	assert.equal(oq.len(), 1);
 
-	assert.deepEqual(oq.remove(order3.id), order3);
+	assert.deepStrictEqual(oq.remove(order3.id), order3);
 	assert.equal(oq.len(), 0);
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test, { describe } from "node:test";
+import { safeParse, safeStringify } from "../src/utils";
+
+describe("safeStringify", () => {
+	test("should stringify a valid object", () => {
+		const obj = { name: "Alice", age: 25 };
+		const result = safeStringify(obj);
+		assert.strictEqual(result, JSON.stringify(obj));
+	});
+
+	test("should return null for objects with circular references", () => {
+		const obj = {};
+		// @ts-expect-error self does not exist on {}
+		obj.self = obj; // Riferimento circolare
+		const result = safeStringify(obj);
+		assert.strictEqual(result, null);
+	});
+
+	test("should handle non-object values gracefully", () => {
+		const result = safeStringify(null);
+		assert.strictEqual(result, JSON.stringify(null));
+	});
+
+	test("should handle arrays correctly", () => {
+		const arr = [1, 2, 3];
+		const result = safeStringify(arr);
+		assert.strictEqual(result, JSON.stringify(arr));
+	});
+});
+
+describe("safeParse", () => {
+	test("should parse a valid JSON string", () => {
+		const jsonStr = '{"name":"Alice","age":25}';
+		const result = safeParse(jsonStr);
+		assert.deepStrictEqual(result, { name: "Alice", age: 25 });
+	});
+
+	test("should return null for invalid JSON strings", () => {
+		const invalidJson = '{name:"Alice",age:25}'; // JSON non valido
+		const result = safeParse(invalidJson);
+		assert.strictEqual(result, null);
+	});
+
+	test("should handle an empty string gracefully", () => {
+		const result = safeParse("");
+		assert.strictEqual(result, null);
+	});
+
+	test("should handle JSON strings representing non-object types", () => {
+		const jsonStr = '"hello"'; // Stringa valida in JSON
+		const result = safeParse(jsonStr);
+		assert.strictEqual(result, "hello");
+	});
+
+	test("should handle arrays correctly", () => {
+		const jsonStr = "[1,2,3]";
+		const result = safeParse(jsonStr);
+		assert.deepStrictEqual(result, [1, 2, 3]);
+	});
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/fasenderos/nodejs-order-book/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs (README.md) have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, the order book returns an instance of the `BaseOrder` class (`new BaseOrder()`).

Issue Number: #472

## What is the new behavior?
Now we returns the underlying object instead.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

The OrderBook previously returned an instance of the `BaseOrder` class (`new BaseOrder()`) for its orders. With this update, it now returns the underlying plain object instead

## Other information
